### PR TITLE
fix: update axios to ^1.15.0 - resolve CVE-2025-62718 (Critical SSRF)

### DIFF
--- a/5-browser-extension/solution/package.json
+++ b/5-browser-extension/solution/package.json
@@ -20,6 +20,6 @@
 		"webpack-cli": "^3.3.12"
 	},
 	"dependencies": {
-  		"axios": "^0.21.1"
+  		"axios": "^1.15.0"
 	}
 }

--- a/5-browser-extension/start/package.json
+++ b/5-browser-extension/start/package.json
@@ -20,6 +20,6 @@
 		"webpack-cli": "^3.3.12"
 	},
 	"dependencies": {
-		"axios": "^0.19.2"
+		"axios": "^1.15.0"
 	}
 }


### PR DESCRIPTION
## 🔒 Security Fix: CVE-2025-62718\n\n### Vulnerabilidad\n**Axios NO_PROXY Hostname Normalization Bypass Leads to SSRF**\n- **Severidad:** Crítica (CVSS 9.9)\n- **CVE:** CVE-2025-62718\n\n### Cambios\n- Actualizado `axios` de `^0.19.2` a `^1.15.0` en `5-browser-extension/start/package.json`\n- Actualizado `axios` de `^0.21.1` a `^1.15.0` en `5-browser-extension/solution/package.json`\n\n### Descripción\nVersiones anteriores a 1.15.0 de Axios no normalizaban correctamente los hostnames al evaluar las reglas `NO_PROXY`, permitiendo ataques SSRF contra infraestructura interna.